### PR TITLE
feat: add GraphQL schema, resolvers, and mock data for backend setup

### DIFF
--- a/src/mockData.js
+++ b/src/mockData.js
@@ -1,0 +1,48 @@
+/**
+ * this is where mock data for testing in development will go
+ *
+ */
+const hosts = [
+  {
+    id: "1",
+    name: "Alice",
+    properties: ["1", "2"],
+  },
+];
+
+const properties = [
+  {
+    id: "1",
+    name: "Cozy Cabin",
+    address: "123 Forest Lane",
+    hostId: "1",
+  },
+  {
+    id: "2",
+    name: "Beach House",
+    address: "456 Ocean Ave",
+    hostId: "1",
+  },
+];
+
+const cleaners = [
+  {
+    id: "1",
+    name: "Bob",
+    cleaningSessions: ["1"],
+  },
+];
+
+const cleaningSessions = [
+  {
+    id: "1",
+    propertyId: "1",
+    cleanerId: "1",
+    tasks: ["Sweep floors", "Change linens"],
+    startTime: "2024-12-01T10:00:00Z",
+    endTime: "2024-12-01T12:00:00Z",
+    notes: "Check lightbulbs",
+  },
+];
+
+module.exports = { hosts, properties, cleaners, cleaningSessions };

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -1,7 +1,148 @@
+// Import the mock data from mockData.js
+const { hosts, properties, cleaners, cleaningSessions } = require("./mockData");
+
 const resolvers = {
+  // Define Query resolvers to fetch data
   Query: {
-    hello: () => "Hello from your backend",
+    // Resolver for fetching filtered cleaning sessions
+    cleaningSessions: (_, { filter }) => {
+      let results = cleaningSessions; // Start with all cleaning sessions
+
+      // Filter by propertyId if provided
+      if (filter?.propertyId) {
+        results = results.filter(
+          (session) => session.propertyId === filter.propertyId
+        );
+      }
+
+      // Filter by cleanerId if provided
+      if (filter?.cleanerId) {
+        results = results.filter(
+          (session) => session.cleanerId === filter.cleanerId
+        );
+      }
+      // Filter by date range if start and/or end is provided
+      if (filter?.start) {
+        results = results.filter(
+          (session) => new Date(session.startTime) >= new Date(filter.start)
+        );
+      }
+      if (filter?.end) {
+        results = results.filter(
+          (session) => new Date(session.endTime) <= new Date(filter.end)
+        );
+      }
+
+      return results;
+    },
+
+    // Resolver for fetching all hosts
+    hosts: () => hosts,
+
+    // Resolver for fetching all properties
+    properties: () => properties,
+
+    // Resolver for fetching all cleaners
+    cleaners: () => cleaners,
+
+    // Resolver for fetching all cleaning sessions
+    cleaningSessions: () => cleaningSessions,
+  },
+
+  // Define relationships for the Host type
+  Host: {
+    // Resolver to fetch properties belonging to a specific host
+    properties: (host) =>
+      // Filter properties where the hostId matches the current host's id
+      properties.filter((property) => property.hostId === host.id),
+  },
+
+  // Define relationships for the Property type
+  Property: {
+    // Resolver to fetch the host for a specific property
+    host: (property) =>
+      // Find the host where the host id matches the hostId of the property
+      hosts.find((host) => host.id === property.hostId),
+  },
+
+  // Define relationships for the Cleaner type
+  Cleaner: {
+    // Resolver to fetch cleaning sessions associated with a cleaner
+    cleaningSessions: (cleaner) =>
+      // Filter cleaning sessions where the session id is in the cleaner's cleaningSessions array
+      cleaningSessions.filter((session) =>
+        cleaner.cleaningSessions.includes(session.id)
+      ),
+  },
+
+  // Define relationships for the CleaningSession type
+  CleaningSession: {
+    // Resolver to fetch the property associated with a cleaning session
+    property: (session) =>
+      // Find the property where the property id matches the propertyId of the session
+      properties.find((property) => property.id === session.propertyId),
+
+    // Resolver to fetch the cleaner associated with a cleaning session
+    cleaner: (session) =>
+      // Find the cleaner where the cleaner id matches the cleanerId of the session
+      cleaners.find((cleaner) => cleaner.id === session.cleanerId),
+  },
+
+  Mutation: {
+    // Mutation to allow users to create new cleaning sessions.
+    logCleaningSession: (_, { input }) => {
+      // Generate a new ID
+      const newSession = {
+        id: (cleaningSessions.length + 1).toString(),
+        propertyId: input.propertyId,
+        cleanerId: input.cleanerId,
+        tasks: input.tasks,
+        startTime: input.startTime,
+        endTime: input.endTime,
+        notes: input.notes,
+      };
+
+      // Push the new session to the mock data array
+      cleaningSessions.push(newSession);
+
+      return newSession; // Return the newly created session
+    },
+    // Mutation to Update a Cleaning Session
+    updateCleaningSession: (_, { id, input }) => {
+      // Find the session to update
+      const sessionIndex = cleaningSessions.findIndex(
+        (session) => session.id === id
+      );
+
+      if (sessionIndex === -1) {
+        throw new Error(`CleaningSession with ID ${id} not found`);
+      }
+
+      // Update the session with the new input
+      const updatedSession = {
+        ...cleaningSessions[sessionIndex],
+        ...input, // Merge old data with new data
+      };
+
+      cleaningSessions[sessionIndex] = updatedSession;
+
+      return updatedSession; // Return the updated session
+    },
+    // Mutation to Delete a Cleaning Session
+    deleteCleaningSession: (_, { id }) => {
+      const initialLength = cleaningSessions.length;
+
+      // Find the index of the session to remove
+      const index = cleaningSessions.findIndex((session) => session.id === id);
+
+      if (index > -1) {
+        cleaningSessions.splice(index, 1); // Remove 1 element at the found index
+      }
+
+      return cleaningSessions.length < initialLength; // Return true if deletion was successful
+    },
   },
 };
 
+// Export the resolvers so they can be used in the Apollo Server
 module.exports = resolvers;

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,8 +1,181 @@
 const { gql } = require("apollo-server");
 
 const typeDefs = gql`
+  scalar DateTime
+  """
+  Represents a host who owns or manages properties.
+  """
+  type Host {
+    id: ID!
+    name: String!
+    properties: [Property!]!
+  }
+  """
+  Represents a property that can be cleaned.
+  """
+  type Property {
+    id: ID!
+    name: String!
+    address: String!
+    host: Host!
+  }
+  """
+  Represents a cleaner who performs cleaning sessions
+  """
+  type Cleaner {
+    id: ID!
+    name: String!
+    # Add more fields such as email, phone number, etc.
+    cleaningSessions: [CleaningSession!]!
+  }
+  """
+  Represents a cleaning session performed on a specific property
+  by a specific cleaner.
+  """
+  type CleaningSession {
+    id: ID!
+    property: Property!
+    cleaner: Cleaner!
+    tasks: [String!]!
+    startTime: DateTime!
+    endTime: DateTime!
+    notes: String
+  }
+  """
+  Input type for filtering cleaning sessions
+  """
+  input CleaningSessionFilter {
+    propertyId: ID
+    cleanerId: ID
+    start: DateTime
+    end: DateTime
+  }
+  """
+  Input for logging a new cleaning session
+  """
+  input LogCleaningSessionInput {
+    propertyId: ID!
+    cleanerId: ID!
+    tasks: [String!]!
+    startTime: DateTime!
+    endTime: DateTime!
+    notes: String
+  }
+  """
+  Input type for creating a new property
+  """
+  input CreatePropertyInput {
+    hostId: ID!
+    name: String!
+    address: String!
+  }
+  """
+  Input type for updating an existing property
+  """
+  input UpdatePropertyInput {
+    id: ID!
+    name: String
+    address: String
+  }
+  """
+  Input type for creating new host
+  """
+  input CreateHostInput {
+    name: String!
+  }
+  """
+  Input for creating a new cleaner
+  """
+  input CreateCleanerInput {
+    name: String!
+  }
+  """
+  Input for updating cleaner details
+  """
+  input UpdateCleanerInput {
+    id: ID!
+    name: String
+  }
+
   type Query {
-    hello: String
+    """
+    Fetches an array of cleaning sessions, optionally filtered by property, cleaner, or time range.
+    """
+    cleaningSessions(filter: CleaningSessionFilter): [CleaningSession!]!
+
+    """
+    Fetch all properties
+    """
+    properties: [Property!]!
+
+    """
+    Fetch a single property by its ID.
+    """
+    property(id: ID!): Property
+
+    """
+    Fetch a single host by its ID.
+    """
+    host(id: ID!): Host
+
+    """
+    Fetch all hosts
+    """
+    hosts: [Host!]!
+
+    """
+    Fetch a single cleaner by its ID.
+    """
+    cleaner(id: ID!): Cleaner
+
+    """
+    Fetch all cleaners
+    """
+    cleaners: [Cleaner!]!
+  }
+
+  type Mutation {
+    """
+    Logs a new cleaning session for a given property and cleaner.
+    """
+    logCleaningSession(input: LogCleaningSessionInput!): CleaningSession!
+
+    """
+    Creates a new property associated with a host
+    """
+    createProperty(input: CreatePropertyInput!): Property!
+
+    """
+    Updates a property (partial updates allowed)
+    """
+    updateProperty(input: UpdatePropertyInput!): Property!
+
+    """
+    Updates a cleaning session
+    """
+    updateCleaningSession(
+      id: ID!
+      input: LogCleaningSessionInput!
+    ): CleaningSession!
+    """
+    Delete cleaning session
+    """
+    deleteCleaningSession(id: ID!): Boolean!
+
+    """
+    Creates a new host
+    """
+    createHost(input: CreateHostInput): Host!
+
+    """
+    Creates a new cleaner
+    """
+    createCleaner(input: CreateCleanerInput!): Cleaner!
+
+    """
+    Updates an existing cleaner(partial updates allowed).
+    """
+    updateCleaner(input: UpdateCleanerInput!): Cleaner!
   }
 `;
 


### PR DESCRIPTION
This pull request introduces the initial GraphQL backend setup for the project. It includes:

**GraphQL Schema:**

Defines types for Host, Property, Cleaner, and CleaningSession.
Includes input types for creating, updating, and filtering data.
Implements queries for fetching data and mutations for logging, updating, and deleting cleaning sessions.
Resolvers:

**Provides logic for fetching mock data for queries.**
Implements relationships between types (e.g., Host.properties, Property.host).
Adds mutation resolvers for creating, updating, and deleting cleaning sessions.
Mock Data:

**Includes mock data for testing the backend without a database.**
Covers hosts, properties, cleaners, and cleaning sessions.
Why This is Needed
This setup is the foundation for the backend of the project. It allows us to:

**Test GraphQL queries and mutations using mock data.**
Build and validate the API structure before integrating a database.
How to Test
Start the server with node index.js (or npm start).

**Open the Apollo Server Playground and test:**

Queries: `cleaningSessions`, `hosts`, `properties`, etc.
Mutations: `logCleaningSession`, `updateCleaningSession`, `deleteCleaningSession`.
Verify that the mock data is being returned correctly and mutations work as expected.